### PR TITLE
bug(acumen_product_query_concern.rb): add is_master field to acumen

### DIFF
--- a/lib/huginn_acumen_product_agent/concerns/acumen_product_query_concern.rb
+++ b/lib/huginn_acumen_product_agent/concerns/acumen_product_query_concern.rb
@@ -138,6 +138,7 @@ module AcumenProductQueryConcern
                 'acumenAttributes' => {
                     'info_alpha_1' => field_value(p, 'Inv_Product.Info_Alpha_1'),
                     'info_boolean_1' => field_value(p, 'Inv_Product.Info_Boolean_1'),
+                    'is_master' => field_value(p, 'Inv_Product.OnWeb_LinkOnly') == '0',
                 },
             }
 


### PR DESCRIPTION
add is_master field to acumen attributes
https://trello.com/c/yolBI8jk/134-asbat-see-products-syncd-correctly-connecting-ismaster-to-custom-field-in-bc