### PR TITLE
bug(acumen_product_query_concern): remove duplicate links from acumen

### DIFF
--- a/lib/huginn_acumen_product_agent/concerns/acumen_product_query_concern.rb
+++ b/lib/huginn_acumen_product_agent/concerns/acumen_product_query_concern.rb
@@ -20,7 +20,16 @@ module AcumenProductQueryConcern
 
     def get_variants_for_ids(acumen_client, ids)
         result = get_linked_products_by_ids(acumen_client, ids)
-        result.select { |link| link['alt_format'].to_s != 0.to_s }
+
+        # Filtering out duplicate links getting sent from acumen
+        filter = []
+        result.each do |link|
+          if (link['alt_format'].to_s != 0.to_s && !link.in?(filter))
+            filter.push(link)
+          end
+        end
+
+        return filter
     end
 
     def get_linked_products_by_ids(acumen_client, ids)


### PR DESCRIPTION
remove duplicate links from acumen. Acumen returns 2 links for a few
products even though within the acumen client it only shows 1 link. So
we are filtering out duplicates here.