### PR TITLE
fix(acumen_product_query_concern): Fix assignment of base sku

### DIFF
--- a/lib/huginn_acumen_product_agent/concerns/acumen_product_query_concern.rb
+++ b/lib/huginn_acumen_product_agent/concerns/acumen_product_query_concern.rb
@@ -405,6 +405,7 @@ module AcumenProductQueryConcern
         result.each do |product|
           if product['model'].length == 1
             product['model'][0]['isDefault'] = true
+            set_base_sku(product, product['model'][0]['sku'])
             next
           else
             physical_formats.each do |val|


### PR DESCRIPTION
Fix assignment of the base sku additional property to ensure that is is set for all products --
including those with only a single variant

https://trello.com/c/1VtiH7PY/277-acumen-product-fetcher-should-set-basesku-correctly