### PR TITLE
bug(acumen_product_agent, acumen_product_query_concern): fix category

### DIFF
--- a/lib/huginn_acumen_product_agent/acumen_product_agent.rb
+++ b/lib/huginn_acumen_product_agent/acumen_product_agent.rb
@@ -112,7 +112,7 @@ module Agents
             ids = event.payload['ids']
             products = get_products_by_ids(client, ids)
             products = get_product_variants(client, products, physical_formats, digital_formats)
-            products = get_master_products_by_id(client, products, physical_formats, digital_formats)
+            products = get_master_products_by_id(client, products)
             products = get_product_categories(client, products)
             products = get_product_contributors(client, products)
 

--- a/lib/huginn_acumen_product_agent/acumen_product_agent.rb
+++ b/lib/huginn_acumen_product_agent/acumen_product_agent.rb
@@ -112,6 +112,7 @@ module Agents
             ids = event.payload['ids']
             products = get_products_by_ids(client, ids)
             products = get_product_variants(client, products, physical_formats, digital_formats)
+            products = get_master_products_by_id(client, products, physical_formats, digital_formats)
             products = get_product_categories(client, products)
             products = get_product_contributors(client, products)
 


### PR DESCRIPTION
fix categories as well as change sync to only run master products that
are active through the sync, other products will still be synced but
they will be variants on master products. If there is any master
products that are not active products and not variants on an active
master product they will not be synced anymore.