### PR TITLE
fix(prod_mkt_query_concern): Fix mapping of product dimensions

### DIFF
--- a/lib/huginn_acumen_product_agent/concerns/prod_mkt_query_concern.rb
+++ b/lib/huginn_acumen_product_agent/concerns/prod_mkt_query_concern.rb
@@ -34,7 +34,7 @@ module ProdMktQueryConcern
           'ProdMkt.Description_Long' => 'description_long',
           'ProdMkt.Height' => 'height',
           'ProdMkt.Width' => 'width',
-          'ProdMkt.Thickness' => 'depth',
+          'ProdMkt.Thickness' => 'thickness',
           'ProdMkt.Meta_Keywords' => 'meta_keywords',
           'ProdMkt.Meta_Description' => 'meta_description',
           'ProdMkt.Extent_Unit' => 'extent_unit',


### PR DESCRIPTION
Fix an error in mapping product marketing data that resulted in blank values for product depth

https://trello.com/c/2vND7zyr/379-usbat-see-product-dimensions