### PR TITLE
fix(alternate_products): Fix an error in the alternate formats filter

### DIFF
--- a/lib/huginn_acumen_product_agent/acumen_client.rb
+++ b/lib/huginn_acumen_product_agent/acumen_client.rb
@@ -237,6 +237,7 @@ class AcumenClient
               <column_name>Product_Link.Link_From_ID</column_name>
               <column_name>Product_Link.Link_To_ID</column_name>
               <column_name>Product_Link.Alt_Format</column_name>
+              <column_name>Product_Link.Inactive</column_name>
             </requested_output>
           </acusoapRequest>
       XML

--- a/lib/huginn_acumen_product_agent/concerns/alternate_products_query_concern.rb
+++ b/lib/huginn_acumen_product_agent/concerns/alternate_products_query_concern.rb
@@ -53,9 +53,10 @@ module AlternateProductsQueryConcern
           'Product_Link.Link_From_ID' => 'from_id',
           'Product_Link.Link_To_ID' => 'to_id',
           'Product_Link.Alt_Format' => 'alt_format',
+          'Product_Link.Inactive' => 'inactive',
         })
 
-        if mapped['alt_format'].to_s != '0' && !mapped.in?(results)
+        if mapped['inactive'] == '0' && mapped['alt_format'].to_s != '0' && !mapped.in?(results)
           results.push(mapped)
         end
 


### PR DESCRIPTION
Fix an error in the alternate formats lookup that failed to filter _inactive_ product links

https://trello.com/c/DCPkK8Ui/580-usbat-see-alternate-product-formats-as-correctly-linked-in-bigcommerce