### PR TITLE
fix(inv_status_query_concern): Fix inv_status lookup

### DIFF
--- a/lib/huginn_acumen_product_agent/concerns/inv_status_query_concern.rb
+++ b/lib/huginn_acumen_product_agent/concerns/inv_status_query_concern.rb
@@ -29,7 +29,9 @@ module ProdMktQueryConcern
           'Inv_Status.Available' => 'quantity',
         })
 
-        results << mapped
+        if (mapped['warehouse'] === 'Main Warehouse')
+          results << mapped
+        end
       rescue => error
         issue_error(AcumenAgentError.new(
           'process_inv_status_response',


### PR DESCRIPTION
Fix an error in the `Inv_Status` lookup and ensure accurate stock numbers are fetched from Acumen

https://trello.com/c/XqWd0a6X/673-asbat-see-correct-product-availability-in-bigcommerce